### PR TITLE
fix ui if no image is passed for element

### DIFF
--- a/resources/views/forms/components/image-checkbox-group.blade.php
+++ b/resources/views/forms/components/image-checkbox-group.blade.php
@@ -204,7 +204,7 @@
 
                     @if ($option['label'])
                         <div
-                            class="p-3 text-center flex-grow flex flex-col justify-center min-h-[3rem] opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-focus-within:opacity-100 absolute inset-0 bg-black/60 transition-opacity duration-200 z-10"
+                            class="p-3 text-center flex-grow flex flex-col justify-center min-h-[3rem] opacity-100 group-hover:opacity-80 group-focus:opacity-100 group-focus-within:opacity-100  inset-0 bg-black/60 transition-opacity duration-200 z-10"
                             id="{{ $getId() }}-{{ $loop->index }}-label"
                         >
                             <span class="text-xs sm:text-sm font-semibold text-white line-clamp-2">


### PR DESCRIPTION
if there's only label passed without image, the text is hidden and size is very small

Before: 
<img width="866" height="288" alt="before" src="https://github.com/user-attachments/assets/0a1b382a-cb11-433b-bac3-a0b99b3ca3d0" />


After:
<img width="858" height="299" alt="after" src="https://github.com/user-attachments/assets/d25bba29-660d-4486-9c0f-752b302a27cc" />
